### PR TITLE
mshow: don't use --quit-at-eof in less by default

### DIFF
--- a/mshow.c
+++ b/mshow.c
@@ -800,7 +800,7 @@ main(int argc, char *argv[])
 		if (!pg) {
 			pg = getenv("PAGER");
 			if (pg && strcmp(pg, "less") == 0) {
-				static char lesscmd[] = "less -RFXe";
+				static char lesscmd[] = "less -RFX";
 				pg = lesscmd;
 			}
 		}


### PR DESCRIPTION
If the user wants it, he can add it to the LESS environment variable.