### PR TITLE
mlist: look at maildir/new too for messages

### DIFF
--- a/mlist.c
+++ b/mlist.c
@@ -53,9 +53,23 @@ static long tcount;
 void
 list(char *prefix, char *file)
 {
+	char *f = NULL;
+
+	if (flagset || iflag) {
+		size_t prefixlen;
+		
+		f = strstr(file, ":2,");
+
+		if (!f &&
+		    (prefix != NULL) && 
+		    (prefixlen = strlen(prefix)) &&
+		    (prefixlen >= 4) &&
+		    (strcmp(prefix + prefixlen - 4, "/new") == 0))
+			f = ":2,";
+	}
+
 	if (flagset) {
 		int sum = 0;
-		char *f = strstr(file, ":2,");
 		if (!f)
 			return;
 		icount++;
@@ -73,7 +87,6 @@ list(char *prefix, char *file)
 	}
 
 	if (iflag) {
-		char *f = strstr(file, ":2,");
 		if (!f)
 			return;
 		imatched++;


### PR DESCRIPTION
when `flagset` or `iflag` are set, search for `":2,"` as before. but if not found, look if `prefix` ends with `"new/"` and if no, consider it is like if it ends with `":2,"` (message unseen).

Closes: #164 