### PR TITLE
mcom: check if a draft was found when invoking `mcom -r`

### DIFF
--- a/mcom
+++ b/mcom
@@ -250,6 +250,11 @@ else
 	draftmime="$(printf '%s\n' "$draft" | sed 's,\(.*\)/cur/,\1/tmp/mime-,')"
 fi
 
+if [ -n "$resume" ] && [ -z "$draft" ]; then
+	echo "mcom: no draft found"
+	exit 1
+fi
+
 [ -z "$resume" ] &&
 {
 	case "$0" in


### PR DESCRIPTION
Without this patch `mcom -r` would invoke $EDITOR on a directory if the
maildir did not contain any drafts. To prevent this from happening,
check if a draft was found before performing any further processing. If
not, terminate mcom with an error message.