### PR TITLE
mlist to list DT_LNK elements

### DIFF
--- a/mlist.c
+++ b/mlist.c
@@ -147,8 +147,10 @@ listdir(char *dir)
 
 		for (bpos = 0; bpos < nread; bpos += d->d_reclen) {
 			d = (struct linux_dirent64 *)(buf + bpos);
-			if (d->d_type != DT_REG && d->d_type != DT_UNKNOWN)
-				continue;
+			if  (  d->d_type != DT_REG
+				&& d->d_type != DT_LNK
+				&& d->d_type != DT_UNKNOWN
+			) continue;
 			if (d->d_name[0] == '.')
 				continue;
 			list(dir, d->d_name);


### PR DESCRIPTION
maildirs containing symlinks are good way to keep
track of some mails, some indexers [1] can use
this way to store the result of a query so you
can use maildir tools to do whatever you want
with the entries.

it would be convenient to use mblaze as well.

1: at least

* [mu](https://www.djcbsoftware.nl/code/mu/)

    mu find -r --learlinks --format=links --linksdir=/tmp/s

* [notmuch](notmuchmail.org/) AFAIR