### PR TITLE
mrep: Set From header according to To/Cc header

### DIFF
--- a/man/mblaze-profile.5
+++ b/man/mblaze-profile.5
@@ -44,6 +44,9 @@ to recognize messages sent to you.
 A comma-separated list of mail addresses that also belong to you, for
 .Xr mscan 1
 to recognize messages sent by or directly to you.
+.It Li Reply-From\&:
+A comma-separated list of mail addresses that are automatically used for
+the From header in a reply if present in the Cc, To, or Bcc header.
 .It Li FQDN\&:
 The fully qualified domain name used for
 .Li Message\&-Id\&:

--- a/mcom
+++ b/mcom
@@ -10,14 +10,18 @@ commajoin() {
 	     END {print l}'
 }
 
-notmine() {
+grepmine() {
 	mine="$(maddr -a -h local-mailbox:alternate-mailboxes: "$MBLAZE/profile")"
-	grep -Fv -e "$mine"
+	grep -F -e "$mine" "$@"
 }
 
 replyfrom() {
 	addrs="$(maddr -a -h reply-from: "$MBLAZE/profile")"
-	grep -F -e "$addrs"
+	if [ -z "$addrs" ]; then
+		grepmine
+	else
+		grep -F -e "$addrs"
+	fi
 }
 
 ouniq() {
@@ -354,7 +358,7 @@ fi
 			printf 'To: %s\n' "$to"
 			printf 'Cc: %s\n' \
 			       "$(mhdr -d -A -h to:cc: "$1" |
-				       notmine |grep -Fv -e "$to" |
+				       grepmine -v |grep -Fv -e "$to" |
 				       ouniq |commajoin)"
 			printf 'Bcc: \n'
 			printf '%s\n' "$hdrs" | awk '{ print }' |
@@ -364,7 +368,8 @@ fi
 
 		addr=$(maddr -a -h to:cc:bcc: "$1" | replyfrom | head -n1)
 		if [ -n "$addr" ]; then
-			from=$(maddr -h reply-from "$MBLAZE/profile" | grep -Fi "<$addr>" | head -n1)
+			from=$(maddr -h reply-from:local-mailbox:alternate-mailboxes: \
+				"$MBLAZE/profile" | grep -Fi "<$addr>" | head -n1)
 		fi
 		if [ -z "$from" ]; then
 			from=$(mhdr -h local-mailbox "$MBLAZE/profile")

--- a/mcom
+++ b/mcom
@@ -15,6 +15,11 @@ notmine() {
 	grep -Fv -e "$mine"
 }
 
+replyfrom() {
+	addrs="$(maddr -a -h reply-from: "$MBLAZE/profile")"
+	grep -F -e "$addrs"
+}
+
 ouniq() {
 	awk '!seen[$0]++'
 }
@@ -356,7 +361,15 @@ fi
 				msed "/body/d" /dev/stdin
 		fi | sed '/^$/d'
 		printf 'Subject: Re: %s\n' "$(COLUMNS=10000 mscan -f '%S' "$1")"
-		from=$(mhdr -h local-mailbox "$MBLAZE/profile")
+
+		addr=$(maddr -a -h to:cc:bcc: "$1" | replyfrom | head -n1)
+		if [ -n "$addr" ]; then
+			from=$(maddr -h reply-from "$MBLAZE/profile" | grep -Fi "<$addr>" | head -n1)
+		fi
+		if [ -z "$from" ]; then
+			from=$(mhdr -h local-mailbox "$MBLAZE/profile")
+		fi
+
 		[ "$from" ] && printf 'From: %s\n' "$from"
 		mid=$(mhdr -h message-id "$1")
 		if [ "$mid" ]; then


### PR DESCRIPTION
I use different mail addresses for different purposes. When replying to
any email, `mrep(1)` currently uses the mail address configured as
`Local-Mailbox` for the From header. While generally desirable, I do not
want to reply to mails I received through my work address with my
private email address.

This commit introduces a change which uses the email address, the email
was sent to, (as specified by To/Cc) for the From header, as long as this
address was configured as an `Alternate-Mailboxes`. I just quickly hacked
this together as a proof of concept without much further considerations.
Seems to work though but not sure if it is generally desirable to enable
this behaviour by default, let me know what you think.