### PR TITLE
mthread: hide message count behind -n

### DIFF
--- a/man/mthread.1
+++ b/man/mthread.1
@@ -1,4 +1,4 @@
-.Dd May 4, 2020
+.Dd May 16, 2020
 .Dt MTHREAD 1
 .Os
 .Sh NAME
@@ -6,7 +6,7 @@
 .Nd arrange messages into discussions
 .Sh SYNOPSIS
 .Nm
-.Op Fl vpr
+.Op Fl nvpr
 .Op Fl S Ar msg
 .Op Ar msgs\ ...
 .Sh DESCRIPTION
@@ -31,6 +31,8 @@ Unresolved Message-IDs are printed as-is.
 .Pp
 The options are as follows:
 .Bl -tag -width Ds
+.It Fl n
+Print how many messages were threaded to standard error.
 .It Fl v
 Do not prune unresolved Message-IDs at the top-level.
 .It Fl p

--- a/mthread.c
+++ b/mthread.c
@@ -20,6 +20,7 @@
 
 #include "blaze822.h"
 
+static int nflag;
 static int vflag;
 static int pflag;
 static int rflag;
@@ -420,14 +421,15 @@ main(int argc, char *argv[])
 
 	optional = 1;
 
-	while ((c = getopt(argc, argv, "S:prv")) != -1)
+	while ((c = getopt(argc, argv, "S:nprv")) != -1)
 		switch (c) {
 		case 'S': blaze822_loop1(optarg, thread); break;
+		case 'n': nflag = 1; break;
 		case 'v': vflag = 1; break;
 		case 'p': pflag = 1; break;
 		case 'r': rflag = 1; break;
 		default:
-			fprintf(stderr, "Usage: mthread [-vpr] [-S dir] [msgs...]\n");
+			fprintf(stderr, "Usage: mthread [-nvpr] [-S dir] [msgs...]\n");
 			exit(1);
 		}
 
@@ -447,7 +449,8 @@ main(int argc, char *argv[])
 	sort_tree(top, -1);
 	print_tree(top, -1);
 
-	fprintf(stderr, "%ld mails threaded\n", i);
+	if (nflag)
+		fprintf(stderr, "%ld mails threaded\n", i);
 
 	return 0;
 }


### PR DESCRIPTION
See also: ddd7e54fbbf6747ccefabbbad0087debcaec2ca5

It would probably be preferable to use the same flag as used by mscan
(i.e. `-v`). Unfortunately, mthread uses the `-v` flag for another purpose
already.