### PR TITLE
mpick: Freeing of pointer returned by getenv causes memory errors

### DIFF
--- a/mpick.c
+++ b/mpick.c
@@ -574,7 +574,8 @@ parse_string(char **s)
 		*pos = 0;
 		*s = getenv(e);
 		if (!*s)
-			*s = xstrdup("");
+			*s = "";
+		*s = xstrdup(*s);
 		*pos = t;
 		ws();
 		return 1;

--- a/t/2000-mpick.t
+++ b/t/2000-mpick.t
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 cd ${0%/*}
 . ./lib.sh
-plan 28
+plan 29
 
 rm -rf test.dir
 mkdir test.dir
@@ -131,3 +131,5 @@ check_test 'multi redir' -eq 4 'mlist inbox | mpick ./expr | wc -l'
 check_test 'multi redir prefixes' -eq 2 'mlist inbox | mpick ./expr | cut -d: -f1 | sort -u | wc -l'
 
 )
+
+check 'environment variable' 'mlist inbox | MSGID="<EOH1F3NUOY.2KBVMHSBFATNY@example.org>" mpick -t "\"message-id\" == \$MSGID"'


### PR DESCRIPTION
With 95a9c08 mpick started crashing with memory errors (segfaults with musl-libc, aborts with glibc) when environment variables were used in test expressions. This is caused by the return value of `getenv()` being treated the same way as memory allocated with `malloc`/`xstrdup`/..., including being passed to `free()`.