### PR TITLE
pledge(2) all programs

### DIFF
--- a/maddr.c
+++ b/maddr.c
@@ -7,6 +7,7 @@
 #include <unistd.h>
 
 #include "blaze822.h"
+#include "xpledge.h"
 
 static int aflag;
 static int dflag;
@@ -107,6 +108,8 @@ main(int argc, char *argv[])
 			    "Usage: maddr [-ad] [-h headers] [msgs...]\n");
 			exit(1);
 		}
+
+	xpledge("stdio rpath", "");
 
 	if (argc == optind && isatty(0))
 		blaze822_loop1(":", addr);

--- a/magrep.c
+++ b/magrep.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 
 #include "blaze822.h"
+#include "xpledge.h"
 
 static int aflag;
 static int cflag;
@@ -217,6 +218,8 @@ usage:
 	char *rx = strchr(header, ':');
 	if (!rx)
 		goto usage;
+
+	xpledge("stdio rpath", "");
 
 	*rx++ = 0;
 	int r = regcomp(&pattern, rx, REG_EXTENDED | iflag);

--- a/mdate.c
+++ b/mdate.c
@@ -1,11 +1,17 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "xpledge.h"
+
 int
 main()
 {
 	char buf[64];
-	time_t now = time(0);
+	time_t now;
+
+	xpledge("stdio", "");
+
+	now = time(0);
 
 	ssize_t l = strftime(buf, sizeof buf,
 	    "%a, %d %b %Y %T %z\n", localtime(&now));

--- a/mdeliver.c
+++ b/mdeliver.c
@@ -13,6 +13,7 @@
 #include <unistd.h>
 
 #include "blaze822.h"
+#include "xpledge.h"
 
 /*
 design rationale:
@@ -339,6 +340,8 @@ usage2:
 
 	if (argc != optind+1)
 		goto usage2;
+
+	xpledge("stdio rpath wpath cpath", "");
 
 	targetdir = argv[optind];
 

--- a/mdirs.c
+++ b/mdirs.c
@@ -9,6 +9,7 @@
 
 #include "blaze822.h"
 #include "blaze822_priv.h"
+#include "xpledge.h"
 
 static char sep = '\n';
 int aflag;
@@ -87,6 +88,8 @@ usage:
 
 	if (argc == optind)
 		goto usage;
+
+	xpledge("stdio rpath", "");
 
 	char toplevel[PATH_MAX];
 	if (!getcwd(toplevel, sizeof toplevel)) {

--- a/mexport.c
+++ b/mexport.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 
 #include "blaze822.h"
+#include "xpledge.h"
 
 static int Sflag;
 
@@ -140,6 +141,8 @@ main(int argc, char *argv[])
 		}
 
 	status = 0;
+
+	xpledge("stdio rpath", "");
 
 	if (argc == optind && isatty(0))
 		blaze822_loop1(":", export);

--- a/mflag.c
+++ b/mflag.c
@@ -13,6 +13,7 @@
 
 #include "blaze822.h"
 #include "blaze822_priv.h"
+#include "xpledge.h"
 
 static int8_t flags[255];
 static int vflag = 0;
@@ -133,6 +134,8 @@ main(int argc, char *argv[])
 			);
 			exit(1);
 		}
+
+	xpledge("stdio rpath cpath", "");
 
 	curfile = blaze822_seq_cur();
 

--- a/mflow.c
+++ b/mflow.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 
 #include "blaze822.h"
+#include "xpledge.h"
 
 int column = 0;
 int maxcolumn = 80;
@@ -107,6 +108,8 @@ main(int argc, char *argv[])
 	int force = 0;
 	int delsp = 0;
 
+	xpledge("stdio rpath tty", "");
+
 	char *ct = getenv("PIPE_CONTENTTYPE");
 	if (ct) {
 		char *s, *se;
@@ -129,6 +132,8 @@ main(int argc, char *argv[])
 			close(fd);
 		}
 	}
+
+	xpledge("stdio", "");
 
 	char *maxcols = getenv("MAXCOLUMNS");
 	if (maxcols && isdigit(*maxcols)) {

--- a/mgenmid.c
+++ b/mgenmid.c
@@ -13,6 +13,7 @@
 #include <unistd.h>
 
 #include "blaze822.h"
+#include "xpledge.h"
 
 void
 printb36(uint64_t x)
@@ -35,6 +36,8 @@ int main()
 
 	char *f = blaze822_home_file("profile");
 	struct message *config = blaze822(f);
+
+	xpledge("stdio rpath", "");
 
 	if (config) // try FQDN: first
 		host = blaze822_hdr(config, "fqdn");

--- a/mhdr.c
+++ b/mhdr.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 
 #include "blaze822.h"
+#include "xpledge.h"
 
 static char *hflag;
 static char *pflag;
@@ -244,6 +245,8 @@ main(int argc, char *argv[])
 		}
 
 	status = 1;
+
+	xpledge("stdio rpath", "");
 
 	if (argc == optind && isatty(0))
 		blaze822_loop1(".", header);

--- a/minc.c
+++ b/minc.c
@@ -12,6 +12,7 @@
 
 #include "blaze822.h"
 #include "blaze822_priv.h"
+#include "xpledge.h"
 
 static int qflag;
 static int status;
@@ -75,6 +76,8 @@ usage:
 
 	if (optind == argc)
 		goto usage;
+
+	xpledge("stdio rpath cpath", "");
 
 	status = 0;
 	for (i = optind; i < argc; i++)

--- a/mlist.c
+++ b/mlist.c
@@ -13,6 +13,7 @@
 
 #include "blaze822.h"
 #include "blaze822_priv.h"
+#include "xpledge.h"
 
 /*
 
@@ -271,6 +272,8 @@ usage:
 		}
 
 	int i;
+
+	xpledge("stdio rpath", "");
 
 	for (i = 0, flagsum = 0, flagset = 0; (size_t)i < sizeof flags; i++) {
 		if (flags[i] != 0)

--- a/mmime.c
+++ b/mmime.c
@@ -16,6 +16,7 @@
 #include <unistd.h>
 
 #include "blaze822.h"
+#include "xpledge.h"
 
 static int cflag;
 static int rflag;
@@ -519,6 +520,8 @@ usage:
 
 	if (argc != optind)
 		goto usage;
+
+	xpledge("stdio rpath", "");
 
 	if (cflag)
 		return check();

--- a/mpick.c
+++ b/mpick.c
@@ -43,6 +43,7 @@
 #include <wchar.h>
 
 #include "blaze822.h"
+#include "xpledge.h"
 
 enum op {
 	EXPR_OR = 1,
@@ -1462,6 +1463,8 @@ main(int argc, char *argv[])
 			fprintf(stderr, "Usage: %s [-Tv] [-t test] [-F file] [msgs...]\n", argv0);
 			exit(1);
 		}
+
+	xpledge("stdio rpath", "");
 
 	void *cb = need_thr ? collect : oneline;
 	if (argc == optind && isatty(0))

--- a/mscan.c
+++ b/mscan.c
@@ -2,6 +2,8 @@
 #define _XOPEN_SOURCE 700
 #endif
 
+#include "xpledge.h"
+
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -549,6 +551,8 @@ main(int argc, char *argv[])
 			exit(1);
 		}
 
+	xpledge("stdio rpath tty proc exec", NULL);
+
 	if (nflag) {
 		if (argc == optind && isatty(0))
 			blaze822_loop1(":", numline);
@@ -584,6 +588,9 @@ main(int argc, char *argv[])
 	}
 	if (ttyfd >= 0)
 		close(ttyfd);
+
+	xpledge("stdio rpath", "");
+
 	if (getenv("COLUMNS"))
 		cols = atoi(getenv("COLUMNS"));
 	if (cols <= 40)

--- a/msed.c
+++ b/msed.c
@@ -11,6 +11,7 @@
 #include <unistd.h>
 
 #include "blaze822.h"
+#include "xpledge.h"
 
 static char *expr;
 
@@ -322,6 +323,8 @@ main(int argc, char *argv[])
 			fprintf(stderr, "Usage: msed [expr] [msgs...]\n");
 			exit(1);
 		}
+
+	xpledge("stdio rpath", "");
 
 	expr = argv[optind];
 	optind++;

--- a/mseq.c
+++ b/mseq.c
@@ -13,6 +13,7 @@
 
 #include "blaze822.h"
 #include "blaze822_priv.h"
+#include "xpledge.h"
 
 static int fflag;
 static int rflag;
@@ -297,6 +298,8 @@ usage:
 			);
 			exit(1);
 		}
+
+	xpledge("stdio rpath wpath cpath", "");
 
 	if (cflag)
 		blaze822_loop1(cflag, overridecur);

--- a/mshow.c
+++ b/mshow.c
@@ -14,6 +14,7 @@
 #include <unistd.h>
 
 #include "blaze822.h"
+#include "xpledge.h"
 
 static int Bflag;
 static int rflag;
@@ -797,6 +798,8 @@ main(int argc, char *argv[])
 			exit(1);
 		}
 
+	xpledge("stdio rpath wpath cpath proc exec", NULL);
+
 	if (!rflag && !xflag && !Oflag && !Rflag)
 		safe_output = 1;
 
@@ -822,17 +825,22 @@ main(int argc, char *argv[])
 	}
 
 	if (xflag) { // extract
+		xpledge("stdio rpath wpath cpath", NULL);
 		extract(xflag, argc-optind, argv+optind, 0);
 	} else if (Oflag) { // extract to stdout
+		xpledge("stdio rpath", NULL);
 		extract(Oflag, argc-optind, argv+optind, 1);
 	} else if (tflag) { // list
+		xpledge("stdio rpath", NULL);
 		if (argc == optind && isatty(0))
 			blaze822_loop1(".", list);
 		else
 			blaze822_loop(argc-optind, argv+optind, list);
 	} else if (Rflag) { // render for reply
+		xpledge("stdio rpath", NULL);
 		blaze822_loop(argc-optind, argv+optind, reply);
 	} else { // show
+		/* XXX pledge: still r/w on the whole file-system + fork/exec */
 		if (!(qflag || rflag || Fflag)) {
 			char *f = getenv("MAILFILTER");
 			if (!f)

--- a/msort.c
+++ b/msort.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 
 #include "blaze822.h"
+#include "xpledge.h"
 
 struct mail {
 	char *file;
@@ -316,6 +317,7 @@ main(int argc, char *argv[])
 			exit(1);
 		}
 
+	xpledge("stdio rpath", "");
 
 	mails = calloc(sizeof (struct mail), mailalloc);
 	if (!mails)

--- a/mthread.c
+++ b/mthread.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 
 #include "blaze822.h"
+#include "xpledge.h"
 
 static int vflag;
 static int pflag;
@@ -418,6 +419,8 @@ main(int argc, char *argv[])
 	int c;
 
 	optional = 1;
+
+	xpledge("stdio rpath", "");
 
 	while ((c = getopt(argc, argv, "S:prv")) != -1)
 		switch (c) {

--- a/xpledge.h
+++ b/xpledge.h
@@ -1,0 +1,26 @@
+#ifndef PLEDGE_H
+#define PLEDGE_H
+
+#ifdef __OpenBSD__
+
+#ifndef _BSD_SOURCE
+#define _BSD_SOURCE
+#endif
+
+#include <err.h>
+#include <unistd.h>
+
+static void
+xpledge(const char *promises, const char *execpromises)
+{
+	if (pledge(promises, execpromises) == -1)
+		err(1, "pledge");
+}
+
+#endif /* __OpenBSD__ */
+
+#elif
+
+#define xpledge(promises, execpromises)) 0
+
+#endif /* PLEDGE_H */


### PR DESCRIPTION
I have checked all pledge calls and added some to ensure all main() functions are pledged as tight as possible.

The only program remaining with a broad pledge is mshow (full filesystem access plus fork/exec). I think the most important improvement there would be to use unveil(2), but I consider adding support for unveil a separate endeavour.

I've been running this code without problems since December (with the exception of mdate which I just pledged), although I have only just rebased my work on all changes that happended in 2020 on master.

/cc @holsta