### PR TITLE
seq: fix printing multiple mmsgs

### DIFF
--- a/seq.c
+++ b/seq.c
@@ -427,17 +427,18 @@ blaze822_seq_next(char *map, char *range, struct blaze822_seq_iter *iter)
 	if (!iter->lines)  // count total lines
 		find_cur(map, iter);
 
-	if (!iter->s) {
-		int ret = parse_range(map, range, &iter->start, &iter->stop,
-		    iter->cur, iter->lines);
-		if (ret == 1) {
-			fprintf(stderr, "can't parse range: %s\n", range);
-			return 0;
-		} else if (ret == 2) {
-			fprintf(stderr, "message not found for specified range: %s\n", range);
-			return 0;
-		}
+	int ret = parse_range(map, range, &iter->start, &iter->stop,
+	    iter->cur, iter->lines);
 
+	if (ret == 1) {
+		fprintf(stderr, "can't parse range: %s\n", range);
+		return 0;
+	} else if (ret == 2) {
+		fprintf(stderr, "message not found for specified range: %s\n", range);
+		return 0;
+	}
+
+	if (!iter->s) {
 		iter->s = map;
 		iter->line = 1;
 	}

--- a/t/7000-mseq.t
+++ b/t/7000-mseq.t
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 cd ${0%/*}
 . ./lib.sh
-plan 10
+plan 11
 
 rm -rf test.dir
 mkdir test.dir
@@ -31,6 +31,7 @@ check_test 'whole thread' -eq 4 'mseq 6= | wc -l'
 check_test  'subthread' -eq 2 'mseq 7_ | wc -l'
 check 'parent' 'mseq 6^ | grep "inbox/cur/5_1:2,"'
 check_test 'range' -eq 3 'mseq 1:3 | wc -l'
+check_same 'multiple mmsg' 'mseq 1 2' 'echo "inbox/cur/1:2,\ninbox/cur/2:2,"'
 
 cat <<! >seq
 inbox/cur/1:2,


### PR DESCRIPTION
According to `mseq(1)`, `mseq` should accept multiple *msgs*.

```
printf 'a\nb\n' | mseq -S
mseq 1 2
```

The above prints:
```
a
```