### PR TITLE
mcom: allow tilde prefixed path for profile's outbox setting

### DIFF
--- a/mcom
+++ b/mcom
@@ -231,7 +231,7 @@ esac
 
 hdrs="$(printf '%s\n' "${hdrs#$NL}" | mhdr -)"
 
-outbox=$(mhdr -h outbox "$MBLAZE/profile")
+outbox=$(mhdr -h outbox "$MBLAZE/profile" | sed "s:^~/:$HOME/:")
 if [ -z "$outbox" ]; then
 	if [ -z "$resume" ]; then
 		i=0


### PR DESCRIPTION
I assumed – perhaps incorrectly – that my `outbox` setting could be `~/Mail/Sent`.  However, doing so fails because the tilde isn’t expanded.  This trivial change fixes that.

Thanks,

James