### PR TITLE
contrib/_mblaze: silence mseq errors

### DIFF
--- a/contrib/_mblaze
+++ b/contrib/_mblaze
@@ -14,7 +14,7 @@ _mblaze_message() {
     _files "$expl[@]" && ret=0
   fi
 
-  curmsg=$(mseq .)
+  curmsg=$(mseq . 2>/dev/null)
   if [[ -z $curmsg || ! -f $curmsg ]]; then
     _message 'no current sequence'
     return $ret


### PR DESCRIPTION
On the first run or if you manually delete your sequence file, `mseq` errors will break your prompt when you hit tab.

Thanks,

James