### PR TITLE
RFC: Allow gpg and gpg2 for gnupg interaction

### DIFF
--- a/contrib/mencrypt
+++ b/contrib/mencrypt
@@ -10,12 +10,18 @@ FLAGS=$(maddr -a -h from:to:cc:bcc: "$1" |sort -u |sed 's/^/--recipient=/')
 FROM=$(maddr -a -h from "$1" | sed 1q)
 [ "$FROM" ] && key="--default-key=$FROM"
 
+if command -v gpg2 >/dev/null; then
+	GPG=gpg2
+else
+	GPG=gpg
+fi
+
 TMPD=$(mktemp -d -t mencrypt.XXXXXX)
 trap "rm -rf '$TMPD'" INT TERM EXIT
 
 awk '/^$/,0' "$1" |
 	mmime |
-	gpg2 "$key" --armor --encrypt --sign $FLAGS -o "$TMPD/msg.asc" ||
+	$GPG "$key" --armor --encrypt --sign $FLAGS -o "$TMPD/msg.asc" ||
 	exit $?
 
 printf 'Version: 1\n' >"$TMPD/version"

--- a/contrib/mgpg
+++ b/contrib/mgpg
@@ -1,5 +1,11 @@
 #!/bin/sh -e
 
+if command -v gpg2 >/dev/null; then
+	GPG=gpg2
+else
+	GPG=gpg
+fi
+
 tmp=$(mktemp -t mgpg.XXXXXX)
 trap "rm -f '$tmp'" INT TERM EXIT
 
@@ -14,7 +20,7 @@ n=$(mshow -t "$tmp" | awk -F: '
 	/: application\/octet-stream/ {if (supported) print $1}')
 
 if [ "$n" ]; then
-	mshow -O "$tmp" "$n" | gpg2 -d 2>&1 || exit 0
+	mshow -O "$tmp" "$n" | $GPG -d 2>&1 || exit 0
 	exit 64
 fi
 exit 63

--- a/contrib/msign
+++ b/contrib/msign
@@ -3,6 +3,12 @@
 
 [ -f "$1" ] || exit 1
 
+if command -v gpg2 >/dev/null; then
+	GPG=gpg2
+else
+	GPG=gpg
+fi
+
 IFS='
 '
 
@@ -13,7 +19,7 @@ FROM=$(maddr -a -h from "$1" | sed 1q)
 [ "$FROM" ] && key="--default-key=$FROM"
 
 awk '/^$/,0' "$1" | mmime | sed 's/$//' >"$TMPD"/content
-gpg2 $key --armor --detach-sign -o "$TMPD"/signature.asc "$TMPD"/content ||
+$GPG $key --armor --detach-sign -o "$TMPD"/signature.asc "$TMPD"/content ||
 	exit $?
 
 {

--- a/contrib/mverify
+++ b/contrib/mverify
@@ -3,6 +3,12 @@
 
 # Needs gpg2 (for OpenPGP) and openssl (for SMIME).
 
+if command -v gpg2 >/dev/null; then
+	GPG=gpg2
+else
+	GPG=gpg
+fi
+
 [ "$#" -eq 0 ] && set -- .
 
 mshow -t "$1" | DOS2UNIX='/$/!s/$//' awk -v "msg=$1" '
@@ -14,7 +20,7 @@ signed && content && !signature && indent == si+2 { signature = 0+$1; type = $2 
 function q(a) { gsub("\\47", "\47\\\47\47", a); return "\47"a"\47" }
 END {
 	if (type == "" && plain) {  // guess plain text armored signature
-		exit(system("mshow -r " q(msg) " | gpg2 --verify"));
+		exit(system("mshow -r " q(msg) " | '$GPG' --verify"));
 	} else if (type == "") {
 		print("No signature found.")
 		exit(100)
@@ -22,7 +28,7 @@ END {
 		exit(system("mshow -r -O " q(msg) " " q(content) \
 			" | sed $DOS2UNIX | " \
 			" { mshow -O " q(msg) " " q(signature) \
-			" | gpg2 --verify - /dev/fd/3; } 3<&0"))
+			" | '$GPG' --verify - /dev/fd/3; } 3<&0"))
 	} else if (type == "application/pkcs7-signature") {
 		exit(system("mshow -r -O " q(msg) " " q(signed) \
 			" | openssl smime -verify"))


### PR DESCRIPTION
The attached commit enables using `gpg` *or* `gpg2` for `gnupg` interaction.  The main reason being that Debian installs `gnupg` v2 as `gpg`, and provides an [additional package of just symlinks for gpg2](https://packages.debian.org/buster/gnupg2).  I’ll additionally note that, for example, `pass` supports using either so I *believe* compatibility isn’t an issue.

Thoughts?

Thanks,

James

---

Refs 08a46e684855ad8c51c154f843fb1d8527045d33, d9aaac690357d55629b8bbdc885235f68e508783 and 87e5a1b2c308dfa9db85cb3cdd9aa105a5046aed.  This purposely doesn’t touch the `GNUmakefile` despite da457c51ee9b0c02c886a7dc641135d3bfa82e63, as you know how your release system works much better than I do ;)
