### PR TITLE
mcom: do not match shebang in needs_multipart()

### DIFF
--- a/mcom
+++ b/mcom
@@ -75,7 +75,7 @@ stripempty() {
 
 needs_multipart() {
 	mhdr -h attach "$1" >/dev/null ||
-		grep -q '^#[^ ]*/[^ ]* ' "$1"
+		grep -qE '^#[a-zA-Z]+/[a-zA-Z0-9+.;=#-]+ ' "$1"
 }
 
 do_mime() {


### PR DESCRIPTION
Avoids matching lines like `#!/usr/bin/env sh`. Also require at least one character after `/`.