### PR TITLE
Match messages without a specific header when "mgrep -v header:match" is used

### DIFF
--- a/magrep.c
+++ b/magrep.c
@@ -37,7 +37,7 @@ match(char *file, char *hdr, char *s)
 		regmatch_t pmatch = {0};
 		int len, matched;
 		matched = 0;
-		while (*s && regexec(&pattern, s, 1, &pmatch, 0) == 0) {
+		while (s && *s && regexec(&pattern, s, 1, &pmatch, 0) == 0) {
 			s += pmatch.rm_so;
 			if (!(len = pmatch.rm_eo-pmatch.rm_so)) {
 				s += 1;
@@ -52,7 +52,7 @@ match(char *file, char *hdr, char *s)
 			matched++;
 		}
 		return (matched && matches++);
-	} else if (vflag ^ (regexec(&pattern, s, 0, 0, 0) == 0)) {
+	} else if (vflag ^ (s && regexec(&pattern, s, 0, 0, 0) == 0)) {
 		if (qflag)
 			exit(0);
 		matches++;
@@ -183,6 +183,8 @@ magrep(char *file)
 		char *v = blaze822_chdr(msg, header);
 		if (v)
 			(void)match_value(file, header, v);
+		else
+			(void)match(file, header, 0);
 	}
 
 	blaze822_free(msg);

--- a/t/3000-magrep.t
+++ b/t/3000-magrep.t
@@ -175,6 +175,7 @@ export MAILSEQ=seq
 check_test 'subject' -eq 1 'magrep subject:nice : | wc -l'
 check_test 'ignorecase' -eq 1 'magrep -i subject:NICE : | wc -l'
 check_test 'invert' -eq 2 'magrep -v subject:nice : | wc -l'
+check_test 'invert missing' -eq 1 'magrep -v subject:i : | wc -l'
 check_test 'max matches' -eq 2 'magrep -m 2 from:Piet : | wc -l'
 check_test 'long subject' -eq 1 'magrep subject:aliqua : | wc -l'
 check_test 'decode large rfc2047 header' -eq 1 'magrep -d to:John : | wc -l'


### PR DESCRIPTION
My main usage is to pipe messages through `mlist ... |magrep -v to:addr |magrep -v cc:addr`.

I'm not sure the patch is complete, but still...