### PR TITLE
mgenmid: add option -d for custom domain

### DIFF
--- a/man/mgenmid.1
+++ b/man/mgenmid.1
@@ -6,6 +6,7 @@
 .Nd generate a Message-ID
 .Sh SYNOPSIS
 .Nm
+[-d domain]
 .Sh DESCRIPTION
 .Nm
 generates and prints a unique Message-ID.
@@ -15,6 +16,10 @@ and a fully qualified domain name.
 .Pp
 The fully qualified domain name is arrived at by:
 .Bl -enum
+.It
+Using the
+.Sq Li domain
+parameter provided on the command line.
 .It
 Using
 .Sq Li FQDN\&:

--- a/mgenmid.c
+++ b/mgenmid.c
@@ -29,17 +29,26 @@ printb36(uint64_t x)
 	fputs(o, stdout);
 }
 
-int main()
+int main(int argc, char *argv[])
 {
 	char hostbuf[1024];
 	char *host = 0;
+
+	int c;
+	while ((c = getopt(argc, argv, "d:")) != -1)
+		switch (c) {
+		case 'd': host = optarg; break;
+		default:
+			  fprintf(stderr, "Usage: mgenmid [-d domain]\n");
+			  exit(1);
+		}
 
 	char *f = blaze822_home_file("profile");
 	struct message *config = blaze822(f);
 
 	xpledge("stdio rpath dns", "");
 
-	if (config) // try FQDN: first
+	if (!host && config) // try FQDN:
 		host = blaze822_hdr(config, "fqdn");
 
 	if (!host && gethostname(hostbuf, sizeof hostbuf) == 0) {


### PR DESCRIPTION
In my setup, I use mblaze across multiple mailboxes, each with different addresses and domains, which they provide through mailbox-local configuration files.  I needed this option in order to select the domain programmatically.