### PR TITLE
blaze822: remove blaze822_mmap, never used.

### DIFF
--- a/blaze822.h
+++ b/blaze822.h
@@ -14,7 +14,6 @@ struct message;
 
 struct message *blaze822(char *file);       // just header
 struct message *blaze822_file(char *file);  // header + body (read(2))
-struct message *blaze822_mmap(char *file);  // header + body (mmap(2))
 struct message *blaze822_mem(char *buf, size_t len);  // header + body
 
 char *blaze822_hdr_(struct message *mesg, const char *hdr, size_t len);

--- a/t/1701-mshow-regress.t
+++ b/t/1701-mshow-regress.t
@@ -1,0 +1,29 @@
+#!/bin/sh -e
+cd ${0%/*}
+. ./lib.sh
+plan 2
+
+# Mail with \n\n and \r\n\r\n
+cr=$(printf '\r')
+cat <<EOF >tmp
+Content-Type: multipart/form-data; boundary=------------------------55a586f81559face$cr
+$cr
+--------------------------55a586f81559face$cr
+Content-Disposition: form-data; name="a"; filename="foo"$cr
+Content-Type: application/octet-stream$cr
+$cr
+foo$cr
+
+previously there are two NL$cr
+$cr
+--------------------------55a586f81559face$cr
+Content-Disposition: form-data; name="a"; filename="bar"$cr
+Content-Type: application/octet-stream$cr
+$cr
+bar$cr
+$cr
+--------------------------55a586f81559face--$cr
+EOF
+
+check 'mail has 3 attachments' 'mshow -t ./tmp | wc -l | grep 4'
+check 'mail attachment foo has size 35' 'mshow -t ./tmp | grep size=35.*name=\"foo\"'


### PR DESCRIPTION
Closes #212.