### PR TITLE
Fix from email determination when replying to some mail group lists

### DIFF
--- a/mcom
+++ b/mcom
@@ -368,7 +368,7 @@ fi
 		printf 'Subject: Re: %s\n' "$(COLUMNS=10000 mscan -f '%S' "$1")"
 		if ! printf '%s\n' "$hdrs" | awk '{ print }' |
 		     mhdr -h from: - >/dev/null; then
-			addr=$(maddr -a -h to:cc:bcc: "$1" | replyfrom | head -n1)
+			addr=$(maddr -a -h delivered-to:to:cc:bcc: "$1" | replyfrom | head -n1)
 			[ -n "$addr" ] && from=$(maddr -h reply-from "$MBLAZE/profile" | grep -Fi "<$addr>" | head -n1)
 			[ -n "$addr" ] && [ -z "$from" ] && from=$(maddr -h alternate-mailboxes "$MBLAZE/profile" | grep -Fi "<$addr>" | head -n1)
 			[ -z "$from" ] && from=$(mhdr -h local-mailbox "$MBLAZE/profile")


### PR DESCRIPTION
I just received a mail coming from a Google Group mail list and it had
the group email as To. So my reply used the default configured mail as
from and not the correct one.

Googles mails provide the target email as Delivered-To. This patch add
this check before the To to prevent this error.