### PR TITLE
allow to override Makefile OS variable

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,7 +2,7 @@ CFLAGS?=-g -O2 -fstack-protector-strong -D_FORTIFY_SOURCE=2
 override CFLAGS:=-Wall -Wno-switch -Wextra $(CFLAGS)
 LDLIBS=-lrt
 
-OS := $(shell uname)
+OS ?= $(shell uname)
 
 ifeq ($(OS),OpenBSD)
 LOCALBASE=/usr/local


### PR DESCRIPTION
Overriding OS is useful for cross-compiling if build OS and
target OS are different (e.g. build on MacOS for Linux)

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>