### PR TITLE
fixes leahneukirchen/mblaze#194

### DIFF
--- a/man/mblaze-profile.5
+++ b/man/mblaze-profile.5
@@ -71,6 +71,9 @@ will be used as a default.
 .It Li Scan\&-Format\&:
 The default format string for
 .Xr mscan 1 .
+.It Li Scan\&-Lines\&:
+The number of lines to scan when using
+.Xr mless 1 .
 .It Li Sendmail\&:
 The program that
 .Xr mcom 1

--- a/man/mless.1
+++ b/man/mless.1
@@ -50,6 +50,9 @@ Additional keybindings loaded for convenience.
 .It Pa ${MBLAZE:-$HOME/.mblaze}/mless , Pa $HOME/.mless
 Additional compiled keybindings loaded for convenience.
 (Only needed for less earlier than version 590.)
+.It Pa ${MBLAZE:-$HOME/.mblaze}/profile
+Number of lines/messages to scan which are shown on top.
+If not set, 6 lines are used as the default.
 .El
 .Sh EXIT STATUS
 .Ex -std

--- a/mless
+++ b/mless
@@ -24,13 +24,15 @@ if [ "$1" = --filter ]; then
 	mseq -C "$2"
 
 	total=$(mscan -n -- -1)
+       linesToScan=$(mhdr -h Scan-Lines "$MBLAZE/profile")
+       linesToScan=${linesToScan:-6}
 	case $2 in
-		1)              mscan .-0:.+5 ;;
-		2)              mscan .-1:.+4 ;;
-		$((total - 2))) mscan .-3:.+2 ;;
-		$((total - 1))) mscan .-4:.+1 ;;
-		$total)         mscan .-5:.+0 ;;
-		*)              mscan .-2:.+3 ;;
+               1)              mscan .-0:.+$(expr $linesToScan - 1) ;;
+		2)              mscan .-1:.+$(expr $linesToScan - 2) ;;
+		$((total - 2))) mscan .-3:.+$(expr $linesToScan - 4) ;;
+		$((total - 1))) mscan .-4:.+$(expr $linesToScan - 5) ;;
+		$total)         mscan .-5:.+$(expr $linesToScan - 6) ;;
+		*)              mscan .-2:.+$(expr $linesToScan - 3) ;;
 	esac 2>/dev/null | colorscan
 	echo
 


### PR DESCRIPTION
**Why**
Configure the number of lines which are shown on top of `mless` would be nice to have.

**How**
Introduce property `Scan-Lines` available in `$MBLAZE/profile` to configure the number of lines to scan on top of `mless`.
`mless` reads this property and using it. if not set the default value of `6` is used to not break the existing behaviour.
Also updating the man pages for mless and `mblaze-profile`.