### PR TITLE
use -fstack-protector-strong for both compiling and linking

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,6 @@
 CFLAGS?=-g -O2 -fstack-protector-strong -D_FORTIFY_SOURCE=2
 override CFLAGS:=-Wall -Wno-switch -Wextra $(CFLAGS)
+LDFLAGS?=-fstack-protector-strong
 LDLIBS=-lrt
 
 OS := $(shell uname)


### PR DESCRIPTION
gcc needs -fstack-protector-strong when linking else `__stack_chk_fail` and `__stack_chk_guard` are not defined (at least on Solaris).