### PR TITLE
solaris needs termios.h and __EXTENSIONS__ for TIOCGWINSZ and winsize

### DIFF
--- a/mflow.c
+++ b/mflow.c
@@ -1,3 +1,7 @@
+#ifdef __sun
+#define __EXTENSIONS__ /* to get TIOCGWINSZ */
+#endif
+
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 
@@ -9,6 +13,7 @@
 #include <string.h>
 #include <strings.h>
 #include <unistd.h>
+#include <termios.h>
 
 #include "blaze822.h"
 #include "xpledge.h"

--- a/mscan.c
+++ b/mscan.c
@@ -1,6 +1,9 @@
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 700
 #endif
+#ifdef __sun
+#define __EXTENSIONS__ /* to get TIOCGWINSZ */
+#endif
 
 #include "xpledge.h"
 
@@ -19,6 +22,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <wchar.h>
+#include <termios.h>
 
 #include "blaze822.h"
 #include "u8decode.h"


### PR DESCRIPTION
Address Solaris compile-time issues in mshow and mscan related to TIOCGWINSZ