### PR TITLE
mcom: quote sequence for mbnc and mrep

### DIFF
--- a/mcom
+++ b/mcom
@@ -321,7 +321,10 @@ fi
 		) fi
 		;;
 	*mbnc*)
+		old_ifs="$IFS"
+		IFS=$NL
 		set -- $(mseq -- "$@")
+		IFS="$old_ifs"
 		if [ "$#" -ne 1 ]; then
 			printf 'mbnc: needs exactly one mail to bounce\n' 1>&2
 			exit 1
@@ -344,7 +347,10 @@ fi
 		)
 		;;
 	*mrep*)
+		old_ifs="$IFS"
+		IFS=$NL
 		set -- $(mseq -- "$@")
+		IFS="$old_ifs"
 		if [ "$#" -ne 1 ]; then
 			printf 'mrep: needs exactly one mail to reply to\n' 1>&2
 			exit 1


### PR DESCRIPTION
I was getting the "mrep: needs exactly one mail to reply to" error when trying to reply to messages, where the file was located in a directory with spaces. With this change, I was able to use `mrep` in such a case. I noticed the same code in `mbnc`, so I also applied the change there.