### PR TITLE
improve named part/attachment detection

### DIFF
--- a/mshow.c
+++ b/mshow.c
@@ -158,7 +158,7 @@ mime_filename(struct message *msg)
 	static char buf[512];
 	char *v;
 	char *filename = 0;
-	
+
 	if ((v = blaze822_hdr(msg, "content-disposition")) &&
 	    blaze822_mime2231_parameter(v, "filename",
 	    buf, sizeof buf, "UTF-8")) {

--- a/mshow.c
+++ b/mshow.c
@@ -158,11 +158,11 @@ mime_filename(struct message *msg)
 	static char buf[512];
 	char *v;
 	char *filename = 0;
-
-	if ((v = blaze822_hdr(msg, "content-disposition"))) {
-		if (blaze822_mime2231_parameter(v, "filename",
-		    buf, sizeof buf, "UTF-8"))
-			filename = buf;
+	
+	if ((v = blaze822_hdr(msg, "content-disposition")) &&
+	    blaze822_mime2231_parameter(v, "filename",
+	    buf, sizeof buf, "UTF-8")) {
+		filename = buf;
 	} else if ((v = blaze822_hdr(msg, "content-type"))) {
 		if (blaze822_mime2231_parameter(v, "name",
 		    buf, sizeof buf, "UTF-8"))

--- a/t/1702-mshow-attachments.t
+++ b/t/1702-mshow-attachments.t
@@ -1,0 +1,53 @@
+#!/bin/sh -e
+cd ${0%/*}
+. ./lib.sh
+plan 2
+
+# Different naming scenarios for named parts
+cat <<EOF >tmp
+Content-Type: multipart/mixed; boundary=----_NextPart_000_00DE_01D6A2E8.A7446C80
+
+------_NextPart_000_00DE_01D6A2E8.A7446C80
+
+no header, part is not attachment
+------_NextPart_000_00DE_01D6A2E8.A7446C80
+Content-Type: text/plain; charset=UTF-8
+
+CT w/o name, part is not attachment
+------_NextPart_000_00DE_01D6A2E8.A7446C80
+Content-Type: text/plain; charset=UTF-8; name="ctn.txt"
+
+CT with name, part is attachment
+------_NextPart_000_00DE_01D6A2E8.A7446C80
+Content-Disposition: attachment
+
+CD w/o filename, part is not attachment
+------_NextPart_000_00DE_01D6A2E8.A7446C80
+Content-Type: text/plain; charset=UTF-8
+Content-Disposition: attachment
+
+CD w/o filename, CT w/o name, part is not attachment
+------_NextPart_000_00DE_01D6A2E8.A7446C80
+Content-Type: text/plain; charset=UTF-8; name="cd_ctn.txt"
+Content-Disposition: attachment
+
+CD w/o filename, CT with name, part is attachment
+------_NextPart_000_00DE_01D6A2E8.A7446C80
+Content-Disposition: attachment; filename="cdf.txt"
+
+CD with filename, part is attachment
+------_NextPart_000_00DE_01D6A2E8.A7446C80
+Content-Type: text/plain; charset=UTF-8; name="cdf_ct.txt"
+Content-Disposition: attachment
+
+CD with filename, CT w/o name, part is attachment
+------_NextPart_000_00DE_01D6A2E8.A7446C80
+Content-Type: text/plain; charset=UTF-8; name="cdf_ctn.txt"
+Content-Disposition: attachment; filename="cdf_ctn.txt"
+
+CD with filename, CT with name, part is attachment
+------_NextPart_000_00DE_01D6A2E8.A7446C80--
+EOF
+
+check 'mail has 10 parts' 'mshow -t ./tmp | wc -l | grep 11'
+check 'mail has 5 named parts/attachments' 'mshow -t ./tmp | grep .*name=\".*\" | wc -l | grep 5'


### PR DESCRIPTION
This will add filename detection for parts which specify Content-Disposition _without_ a filename parameter and Content-Type _with_ a name parameter. I'm not sure whether omitting this possibility was intentional, e.g. to adhere to standard, but messages which name their attachments in this way occur in the wild.