### PR TITLE
Add Drafts profile key

### DIFF
--- a/man/mblaze-profile.5
+++ b/man/mblaze-profile.5
@@ -52,8 +52,11 @@ generation in
 .It Li Outbox\&:
 If set,
 .Xr mcom 1
-will create draft messages in this maildir,
-and save messages there after sending.
+will save messages in this maildir after sending.
+.It Li Drafts\&:
+If set,
+.Xr mcom 1
+will create draft messages in this maildir (defaults to Outbox). 
 .It Li Reply-From\&:
 A comma-separated list of display name and mail address pairs, formatted like this:
 .Dl Li Primary Name <myname1@domain1>, Name v.2 <myname2@domain2>, \[dq]Name, My Third\[dq] <myname3@domain3>, ...

--- a/mcom
+++ b/mcom
@@ -236,7 +236,9 @@ esac
 hdrs="$(printf '%s\n' "${hdrs#$NL}" | mhdr -)"
 
 outbox=$(mhdr -h outbox "$MBLAZE/profile" | sed "s:^~/:$HOME/:")
-if [ -z "$outbox" ]; then
+draftbox=$(mhdr -h drafts "$MBLAZE/profile" | sed "s:^~/:$HOME/:")
+draftbox="${draftbox:-$outbox}"
+if [ -z "$draftbox" ]; then
 	if [ -z "$resume" ]; then
 		i=0
 		while [ -f "snd.$i" ]; do
@@ -249,13 +251,13 @@ if [ -z "$outbox" ]; then
 	draftmime="$draft.mime"
 else
 	if [ -z "$resume" ]; then
-		draft="$(true | mdeliver -v -c -XD "$outbox")"
+		draft="$(true | mdeliver -v -c -XD "$draftbox")"
 		if [ -z "$draft" ]; then
-			printf '%s\n' "$0: failed to create draft in outbox $outbox." 1>&2
+			printf '%s\n' "$0: failed to create draft in outbox $draftbox." 1>&2
 			exit 1
 		fi
 	elif [ -z "$draft" ]; then
-		draft=$(mlist -D "$outbox" | msort -r -M | sed 1q)
+		draft=$(mlist -D "$draftbox" | msort -r -M | sed 1q)
 	fi
 	draftmime="$(printf '%s\n' "$draft" | sed 's,\(.*\)/cur/,\1/tmp/mime-,')"
 fi
@@ -446,7 +448,7 @@ while :; do
 				if $sendmail <"$draftmime"; then
 					if [ "$outbox" ]; then
 						mv "$draftmime" "$draft"
-						mflag -d -S "$draft"
+						mrefile $(mflag -d -S "$draft") "$outbox"
 					else
 						rm "$draft" "$draftmime"
 					fi
@@ -464,7 +466,7 @@ while :; do
 				stampdate "$draft"
 				if $sendmail <"$draft"; then
 					if [ "$outbox" ]; then
-						mflag -d -S "$draft"
+						mrefile $(mflag -d -S "$draft") "$outbox"
 					else
 						rm "$draft"
 					fi


### PR DESCRIPTION
Allow the user to set a Drafts key in profile to store draft messages and sent messages separately if Outbox is set.

This commit closes #240 