### PR TITLE
mrep: fix subject not populating when pager stdout is not tty

### DIFF
--- a/mcom
+++ b/mcom
@@ -373,7 +373,7 @@ fi
 			printf '%s\n' "$hdrs" | awk '{ print }' |
 				msed "/body/d" -
 		fi | sed '/^$/d'
-		printf 'Subject: Re: %s\n' "$(COLUMNS=10000 mscan -f '%S' "$1")"
+		printf 'Subject: Re: %s\n' "$(MBLAZE_PAGER=cat COLUMNS=10000 mscan -f '%S' "$1")"
 		if ! printf '%s\n' "$hdrs" | awk '{ print }' |
 		     mhdr -h from: - >/dev/null; then
 			addr=$(maddr -a -h delivered-to:to:cc:bcc: "$1" | replyfrom | head -n1)


### PR DESCRIPTION
If the pager is set to something where stdout is not a TTY, such as a text editor, it causes non-interactive calls to `mscan` to fail with the error: `Fatal error: stdout is not a tty`. When building the subject, `mrep` fetches the subject from the email being replied to using `mscan`, causing this error to manifest and the subject line to end up as: "Re: ". Explicitly setting the pager to `cat` when fetching the email subject in `mrep` prevents this error.