### PR TITLE
mdirs: add Maildir profile key

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -26,10 +26,10 @@ SCRIPT = mcolor mcom mless mmkdir mquote museragent
 all: $(ALL) museragent
 
 $(ALL) : % : %.o
-maddr magrep mdeliver mexport mflag mflow mgenmid mhdr mpick mscan msed mshow \
-  msort mthread : blaze822.o mymemmem.o mytimegm.o
-maddr magrep mdeliver mexport mflag mgenmid mhdr minc mlist mpick mscan msed \
-  mseq mshow msort mthread : seq.o slurp.o mystrverscmp.o
+maddr magrep mdeliver mdirs mexport mflag mflow mgenmid mhdr mpick mscan msed \
+  mshow msort mthread : blaze822.o mymemmem.o mytimegm.o
+maddr magrep mdeliver mdirs mexport mflag mgenmid mhdr minc mlist mpick mscan \
+  msed mseq mshow msort mthread : seq.o slurp.o mystrverscmp.o
 maddr magrep mflow mhdr mpick mscan mshow : rfc2047.o
 magrep mflow mhdr mshow : rfc2045.o
 mshow : filter.o safe_u8putstr.o rfc2231.o pipeto.o

--- a/man/mblaze-profile.5
+++ b/man/mblaze-profile.5
@@ -49,6 +49,10 @@ The fully qualified domain name used for
 .Li Message\&-Id\&:
 generation in
 .Xr mgenmid 1 .
+.It Li Maildir\&:
+If set,
+.Xr mdirs 1
+will use this maildir when no directories are supplied.
 .It Li Outbox\&:
 If set,
 .Xr mcom 1

--- a/man/mdirs.1
+++ b/man/mdirs.1
@@ -1,4 +1,4 @@
-.Dd January 22, 2020
+.Dd July 25, 2023
 .Dt MDIRS 1
 .Os
 .Sh NAME
@@ -16,6 +16,14 @@ for maildir
 .Pq and maildir++
 folders and prints them,
 separated by newlines.
+.Pp
+If
+.Ar dirs
+is not present then use 
+.Sq Li Maildir\&:
+from
+.Pa "${MBLAZE:-$HOME/.mblaze}/profile"
+.Pq if set .
 .Pp
 To
 .Nm ,
@@ -36,10 +44,20 @@ Print folders separated by a NUL character.
 .It Fl a
 Traverse into all subfolders, without considering the maildir++ name conventions.
 .El
+.Sh ENVIRONMENT
+.Bl -tag -width Ds
+.It Ev MBLAZE
+Directory containing mblaze configuration.
+.Po
+Default:
+.Pa $HOME/.mblaze
+.Pc
+.El
 .Sh EXIT STATUS
 .Ex -std
 .Sh SEE ALSO
-.Xr find 1
+.Xr find 1 ,
+.Xr mblaze-profile 5
 .Sh AUTHORS
 .An Leah Neukirchen Aq Mt leah@vuxu.org
 .Sh LICENSE


### PR DESCRIPTION
When `mdirs` is executed without any arguments, look for the `Maildir` key in the profile and use that instead (if set).