### PR TITLE
mcolor: Add coloring support for diffs

### DIFF
--- a/mcolor
+++ b/mcolor
@@ -8,14 +8,18 @@ BEGIN { hdr = 1; if ("NO_COLOR" in ENVIRON || match(ENVIRON["TERM"], "^(dumb|net
 no_color { print; next }
 /\r$/ { sub(/\r$/, "") }
 /^\014$/ { nextmail = 1; print(fg(co("FF",232), $0)); next }
-/^$/ { hdr = 0 }
+/^$/ { hdr = 0; diff = 0 }
 /^-- $/ { ftr = 1 }
+/^diff -/ { diff = 1 }
 /^--- .* ---/ { print fg(co("SEP",242), $0); ftr = 0; sig = 0; next }
 /^-----BEGIN .* SIGNATURE-----/ { sig = 1 }
 nextmail && /^From:/ { hdr = 1 }
 hdr && /^From:/ { print so(fg(co("FROM",119), $0)); next }
 hdr { print fg(co("HEADER",120), $0); next }
 ftr { print fg(co("FOOTER",244), $0); next }
+diff && /^-/ { print fg(co("DIFF_D",160), $0); next }
+diff && /^\+/ { print fg(co("DIFF_I",40), $0); next }
+diff && /^@/ { print fg(co("DIFF_R",226), $0); next }
 /^-----BEGIN .* MESSAGE-----/ ||
 /^-----END .* SIGNATURE-----/ { print fg(co("SIG",244), $0); sig = 0; next }
 sig { print fg(co("SIG",244), $0); next }


### PR DESCRIPTION
Add coloring for diffs sent as part of the email body. This adds support for the following three ENV variables:

- **MCOLOR_DIFF_I**: For (I)nserted lines.
- **MCOLOR_DIFF_D**: For (D)eleted lines
- **MCOLOR_DIFF_R**: For file (R)anges

Since the default theme is quite bright, these default to bright colors as well (Green1, Red1 and Yellow1 from the 256 XTerm colors respectively).