### PR TITLE
Attach all files when forwarding in raw mode

### DIFF
--- a/mcom
+++ b/mcom
@@ -306,6 +306,19 @@ fi
 		msgid
 		museragent
 		cat "$MBLAZE/headers" 2>/dev/null
+		if [ -n "$raw" ]; then
+			prev=$(pwd)
+			attachdir=$(mktemp -d)
+			cd $attachdir
+			trap 'rm -r "$attachdir"' EXIT
+
+			mseq -r "$@" \
+				| xargs -I {} mshow -Bx {} \
+				| xargs -I {} realpath {} \
+				| sed '/^$/d; s/^/Attach: /'
+			cd $prev
+		fi
+
 		printf '\n\n'
 		if [ -z "$raw" ]; then
 			mseq -r "$@" | sed 's:^:#message/rfc822#inline :; s:$:>:'


### PR DESCRIPTION
I want to use forwarding with raw messages because it's just easier to work with from the point of view of receivers. The problem is that when "flattening" the message, attachments are lost. This PR extracts them in a temporary folder and adds them to the message to be sent