### PR TITLE
contrib/mmailto: Fix using longer arguments

### DIFF
--- a/contrib/mmailto
+++ b/contrib/mmailto
@@ -19,7 +19,7 @@ fi
 IFS='
 '
 
-exec $TERMINAL -e mcom $(
+args=$(
 awk -v url="$1" '
 
 function decode(s) {
@@ -47,7 +47,7 @@ BEGIN {
     split(fields[i], kv, "=")
     if (kv[1] != "r") {
       args[length(args)+1] = "-" kv[1]
-      args[length(args)+1] =  kv[2]
+      args[length(args)+1] =  "\"" kv[2] "\""
     }
   }
   for (i in args) {
@@ -56,3 +56,5 @@ BEGIN {
 }
 '
 )
+
+exec $TERMINAL -e "mcom $args"


### PR DESCRIPTION
We put the args to $TERMINAL inside single quotes for terminals that want a single command, and we put arguments extracted from the adress between double quotes to protect from spaces.

This is necessary for `xfce4-terminal` for example, and doesn't break `xterm`