### PR TITLE
Fix typo in reading body from arg

### DIFF
--- a/mcom
+++ b/mcom
@@ -287,7 +287,7 @@ fi
 		printf '\n'
 		(
 			IFS=$NL
-			cat -- /dev/null $(printf '%s' "$hdrs" | mhdr -M -h body -)
+			cat -- /dev/null <(printf '%s' "$hdrs" | mhdr -M -h body -)
 		)
 		printf '\n'
 		;;


### PR DESCRIPTION
When given a body argument like this:

```
mcom foo@bar -body "this is my body"
```

the body isn't taken into account. This is because we try to `cat` from a file called "this is my body", instead of doing a process substitution for a file that fake-contains "this is my body". I believe it is a typo.