### PR TITLE
Fix Out-of-Bounds Array Access in parse_parent

### DIFF
--- a/seq.c
+++ b/seq.c
@@ -326,7 +326,7 @@ parse_parent(char *map, long *starto, long *stopo)
 			indent = 255;
 		previndent[indent] = line;
 		if (line == *starto) {
-			if (previndent[indent-1]) {
+			if (indent > 0 && previndent[indent-1]) {
 				*starto = *stopo = previndent[indent-1];
 				return 0;
 			} else {


### PR DESCRIPTION
Hello, submitting a patch to a Out-of-Bounds Array Access that I found. 

If the case `while (*s && iswsp(*s)) {`  is not satisfied, the value of the variable `ident` remains 0. 
This will make the access `previndent[ident - 1]` to `previndent[-1]` which will lead to undefined behaviour.

The patch adds a check before the call. 