### PR TITLE
mshow: do not increment extraction counter on errors

### DIFF
--- a/mshow.c
+++ b/mshow.c
@@ -548,7 +548,7 @@ extract_mime(int depth, struct message *msg, char *body, size_t bodylen)
 					printf("%s\n", bufptr);
 					writefile(bufptr, body, bodylen);
 				}
-				extractcount++;
+				if (errno == 0) extractcount++;
 			} else if (filename &&
 			    fnmatch(a, filename, FNM_PATHNAME) == 0) {
 				// extract by name
@@ -569,7 +569,7 @@ extract_mime(int depth, struct message *msg, char *body, size_t bodylen)
 					printf("\n");
 					writefile(filename, body, bodylen);
 				}
-				extractcount++;
+				if (errno == 0) extractcount++;
 			}
 		}
 	}


### PR DESCRIPTION
Minimal changes to the base code to fix the return value of `mshow` when the extraction of an attachment fails, e.g., if a file of the same name already exists.